### PR TITLE
Add inject_skip_tag script and docs

### DIFF
--- a/405_chrome_flaky_tests.txt
+++ b/405_chrome_flaky_tests.txt
@@ -1,0 +1,6 @@
+mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
+mod/quiz/tests/behat/editing_remove_question.feature|Delete questions by clicking on the delete icon.
+admin/tool/dataprivacy/tests/behat/datadelete.feature|As a Privacy Officer, I cannot re-submit deletion data request without permission.
+mod/h5pactivity/tests/behat/sending_attempt.feature|Do various attempts and check them with the attempts and user grades reports
+mod/h5pactivity/tests/behat/recent_activity.feature|Student see only his own activity
+mod/h5pactivity/tests/behat/recent_activity.feature|Teacher see each student activity

--- a/500_chrome_flaky_tests.txt
+++ b/500_chrome_flaky_tests.txt
@@ -1,0 +1,6 @@
+mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
+mod/quiz/tests/behat/editing_remove_question.feature|Delete questions by clicking on the delete icon.
+admin/tool/dataprivacy/tests/behat/datadelete.feature|As a Privacy Officer, I cannot re-submit deletion data request without permission.
+mod/h5pactivity/tests/behat/sending_attempt.feature|Do various attempts and check them with the attempts and user grades reports
+mod/h5pactivity/tests/behat/recent_activity.feature|Student see only his own activity
+mod/h5pactivity/tests/behat/recent_activity.feature|Teacher see each student activity

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # moodle-skip-tag-injector
+
+This project provides a script to inject the `@skip` tag into specified flaky scenarios in Moodle Behat test files. 
+This is useful for avoiding the execution of known flaky tests during Continuous Integration (CI) runs, ensuring more stable and reliable test results.
+
+### Purpose
+
+The `inject_skip_tag` script is designed to:
+- Read a list of flaky scenarios and their corresponding file paths.
+- Modify the specified Behat test files by adding the `@skip` tag above the flaky scenarios.
+- Help streamline CI processes by skipping tests that are known to fail intermittently.
+
+### Prerequisites
+
+- A file listing the flaky scenarios in the format: `<relative_file_path>|<scenario_name>`.
+- Access to the Moodle root directory where the Behat test files are located.
+
+### Usage
+
+Run the script with the following parameters:
+### Parameters
+
+- `<branch>`: The branch name (used to locate the flaky scenarios file).
+- `<browser>`: The browser name (used to locate the flaky scenarios file).
+- `<path/to/moodle/root>`: The absolute path to the Moodle root directory.
+
+```
+./inject_skip_tag <branch> <browser> <path/to/moodle/root>
+```
+### Flaky Scenarios File
+
+The script expects a file named `<branch>_<browser>_flaky_tests.txt` in the same directory as the script. Each line in the file should follow this format:
+
+```
+<relative_file_path>|<scenario_name>
+```
+
+- `relative_file_path`: The path to the Behat test file, relative to the Moodle root directory.
+- `scenario_name`: The name of the scenario to skip.
+
+### Output
+
+- The script will inject the `@skip` tag above the specified scenarios in the test files.
+- It will log messages indicating success, warnings for missing scenarios, or errors for missing files.
+
+## Notes
+
+- Ensure the script has execute permissions: `chmod +x inject_skip_tag`.
+- The script modifies test files in place. Use version control to track changes.

--- a/inject_skip_tag
+++ b/inject_skip_tag
@@ -40,9 +40,42 @@ while IFS='|' read -r filepath scenario_name; do
         continue
     fi
 
+    escaped_scenario_name=$(printf '%s\n' "$scenario_name" | sed -e 's/[.[\*^$/]/\\&/g')
+
     # Inject the @skip tag above the scenario.
-    if grep -q "Scenario: ${scenario_name}" "${full_filepath}"; then
-        sed -i "/Scenario: ${scenario_name}/i @skip" "${full_filepath}"
+    if grep -q -E ": ${scenario_name}$" "${full_filepath}"; then
+        awk -v scenario="$scenario_name" '
+      {
+        lines[++n] = $0
+      }
+      $0 ~ "^[[:space:]]*Scenario: " scenario "$" {
+        sceneline = n
+        tagline = n - 1
+
+        # Extract indentation
+        indent = gensub(/^([[:space:]]*).*/, "\\1", 1, lines[sceneline])
+
+        if (tagline > 0) {
+          if (lines[tagline] ~ /^[[:space:]]*@/) {
+            if (lines[tagline] !~ /(^|[[:space:]])@skip([[:space:]]|$)/) {
+              lines[tagline] = lines[tagline] " @skip"
+            }
+          } else {
+            # Shift lines down
+            for (i = n + 1; i > sceneline; i--) {
+              lines[i] = lines[i - 1]
+            }
+            lines[sceneline] = indent "@skip"
+            n++
+          }
+        }
+      }
+      END {
+        for (i = 1; i <= n; i++) {
+          print lines[i]
+        }
+      }
+      ' "$full_filepath" > "$full_filepath.tmp" && mv "$full_filepath.tmp" "$full_filepath"
         echo "Injected @skip tag into ${full_filepath} for scenario: ${scenario_name}"
     else
         echo "Warning: Scenario '${scenario_name}' not found in ${full_filepath}"

--- a/inject_skip_tag
+++ b/inject_skip_tag
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script injects a @skip tag into specified flaky scenarios in Moodle Behat test files.
+# It reads a file containing flaky scenarios and their corresponding file paths,
+# then modifies the test files to include the @skip tag above the specified scenarios.
+
+# Ensure the script receives three parameters: branch, browser, and Moodle directory path/
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <branch> <browser> <path/to/moodle/root>"
+    exit 1
+fi
+
+branch=$1
+browser=$2
+moodle_dir=$3
+
+# Build the flaky scenarios file name.
+FLAKY_SCENARIOS_FILE="$(dirname "$(realpath "$0")")/${branch}_${browser}_flaky_tests.txt"
+echo "Running inject_skip_tag script with ${FLAKY_SCENARIOS_FILE}"
+
+# Check if the file exists
+if [[ ! -f "${FLAKY_SCENARIOS_FILE}" ]]; then
+    echo "Error: Flaky scenarios file not found at ${FLAKY_SCENARIOS_FILE}"
+    exit 1
+fi
+
+# Process each line in the file.
+while IFS='|' read -r filepath scenario_name; do
+    # Skip empty lines or comments
+    if [[ -z "${filepath}" || -z "${scenario_name}" || "${filepath}" =~ ^# ]]; then
+        continue
+    fi
+
+    # Prepend the Moodle directory path to the filepath.
+    full_filepath="${moodle_dir}/${filepath}"
+
+    # Check if the test file exists.
+    if [[ ! -f "${full_filepath}" ]]; then
+        echo "Error: Test file not found at ${full_filepath}"
+        continue
+    fi
+
+    # Inject the @skip tag above the scenario.
+    if grep -q "Scenario: ${scenario_name}" "${full_filepath}"; then
+        sed -i "/Scenario: ${scenario_name}/i @skip" "${full_filepath}"
+        echo "Injected @skip tag into ${full_filepath} for scenario: ${scenario_name}"
+    else
+        echo "Warning: Scenario '${scenario_name}' not found in ${full_filepath}"
+    fi
+done < "${FLAKY_SCENARIOS_FILE}"

--- a/main_chrome_flaky_tests.txt
+++ b/main_chrome_flaky_tests.txt
@@ -1,0 +1,6 @@
+public/mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
+public/mod/quiz/tests/behat/editing_remove_question.feature|Delete questions by clicking on the delete icon.
+public/admin/tool/dataprivacy/tests/behat/datadelete.feature|As a Privacy Officer, I cannot re-submit deletion data request without permission.
+public/mod/h5pactivity/tests/behat/sending_attempt.feature|Do various attempts and check them with the attempts and user grades reports
+public/mod/h5pactivity/tests/behat/recent_activity.feature|Student see only his own activity
+public/mod/h5pactivity/tests/behat/recent_activity.feature|Teacher see each student activity


### PR DESCRIPTION
This commits adds the inject_skip_tag and project documentation.

It also adds the chrome flaky test files for main, 500 and 405 with the most annoying randoms at the moment.