### PR TITLE
More firefox flaky tests after update

### DIFF
--- a/flaky_tests/401_chrome_flaky_tests.txt
+++ b/flaky_tests/401_chrome_flaky_tests.txt
@@ -1,3 +1,3 @@
-mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
-course/tests/behat/course_controls.feature|General activities course controls using topics and weeks formats, and paged mode and not paged mode works as expected
-mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature|Verify that students can complete an H5P activity by achieving a passing grade
+Viewing a discussion while grading is fullscreen|mod/forum/tests/behat/grade_view_discussion.feature
+General activities course controls using topics and weeks formats, and paged mode and not paged mode works as expected|course/tests/behat/course_controls.feature
+Verify that students can complete an H5P activity by achieving a passing grade|mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature

--- a/flaky_tests/401_firefox_flaky_tests.txt
+++ b/flaky_tests/401_firefox_flaky_tests.txt
@@ -1,14 +1,23 @@
-contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature|Admins can replace the original .h5p file with a new one
-blocks/tests/behat/hidden_block_region.feature|Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)
-contentbank/tests/behat/view_preferences.feature|Display the number of times a content is used in file details view
-contentbank/tests/behat/view_preferences.feature|There are several views for displaying contents into the content bank
-contentbank/tests/behat/edit_content.feature|Users can edit content if they have the required permission
-contentbank/tests/behat/events.feature|Content created and uploaded events when uploading a content file
-badges/tests/behat/criteria_cohort.feature|Award badge based on a multiple cohort membership or other criteria.
-badges/tests/behat/criteria_cohort.feature|Award badge based on a single cohort membership or other criteria.
-badges/tests/behat/view_badge.feature|Display badge with ANY criteria
-mod/workshop/tests/behat/workshop_completion_pass_grade.feature|As teacher, I can see the completion status of students in the workshop activity
-user/tests/behat/delete_users.feature|Deleting users who have unread messages sent or received
-mod/scorm/tests/behat/multisco_review_mode.feature|Test review mode with all scos completed.
-user/tests/behat/custom_profile_fields_manual.feature|Manual creation of basic custom profile fields
-contentbank/tests/behat/edit_content.feature|Users can see the Add button if there is content type available for creation
+Admins can replace the original .h5p file with a new one|contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature
+Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)|blocks/tests/behat/hidden_block_region.feature
+Display the number of times a content is used in file details view|contentbank/tests/behat/view_preferences.feature
+There are several views for displaying contents into the content bank|contentbank/tests/behat/view_preferences.feature
+Users can edit content if they have the required permission|contentbank/tests/behat/edit_content.feature
+Content created and uploaded events when uploading a content file|contentbank/tests/behat/events.feature
+Award badge based on a multiple cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Award badge based on a single cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Display badge with ANY criteria|badges/tests/behat/view_badge.feature
+As teacher, I can see the completion status of students in the workshop activity|mod/workshop/tests/behat/workshop_completion_pass_grade.feature
+Deleting users who have unread messages sent or received|user/tests/behat/delete_users.feature
+Test review mode with all scos completed.|mod/scorm/tests/behat/multisco_review_mode.feature
+Manual creation of basic custom profile fields|user/tests/behat/custom_profile_fields_manual.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+Block a user who then gets an elevated role|message/tests/behat/block_user.feature
+Preview a user preset as list view template in database|mod/data/tests/behat/preview_preset.feature
+Apply user preset from preview in database|mod/data/tests/behat/preview_preset.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+View full profiles of someone in the same group in a course with separate groups.|user/tests/behat/view_full_profile.feature
+Send a 'contact request' to someone to add a contact|message/tests/behat/message_drawer_manage_contacts.feature
+Unsent messages will notify users and give them a chance to send it|message/tests/behat/message_send_messages.feature
+Decline a 'contact request' from someone|message/tests/behat/message_drawer_manage_contacts.feature
+Users can create new content if they have the required permission|contentbank/tests/behat/edit_content.feature

--- a/flaky_tests/404_chrome_flaky_tests.txt
+++ b/flaky_tests/404_chrome_flaky_tests.txt
@@ -1,7 +1,7 @@
-mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
-mod/quiz/tests/behat/editing_remove_question.feature|Delete questions by clicking on the delete icon.
-admin/tool/dataprivacy/tests/behat/datadelete.feature|As a Privacy Officer, I cannot re-submit deletion data request without permission.
-mod/h5pactivity/tests/behat/sending_attempt.feature|Do various attempts and check them with the attempts and user grades reports
-mod/h5pactivity/tests/behat/recent_activity.feature|Student see only his own activity
-mod/h5pactivity/tests/behat/recent_activity.feature|Teacher see each student activity
-mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature|Verify that students can complete an H5P activity by achieving a passing grade
+Viewing a discussion while grading is fullscreen|mod/forum/tests/behat/grade_view_discussion.feature
+Delete questions by clicking on the delete icon.|mod/quiz/tests/behat/editing_remove_question.feature
+As a Privacy Officer, I cannot re-submit deletion data request without permission.|admin/tool/dataprivacy/tests/behat/datadelete.feature
+Do various attempts and check them with the attempts and user grades reports|mod/h5pactivity/tests/behat/sending_attempt.feature
+Student see only his own activity|mod/h5pactivity/tests/behat/recent_activity.feature
+Teacher see each student activity|mod/h5pactivity/tests/behat/recent_activity.feature
+Verify that students can complete an H5P activity by achieving a passing grade|mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature

--- a/flaky_tests/404_firefox_flaky_tests.txt
+++ b/flaky_tests/404_firefox_flaky_tests.txt
@@ -1,14 +1,23 @@
-contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature|Admins can replace the original .h5p file with a new one
-blocks/tests/behat/hidden_block_region.feature|Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)
-contentbank/tests/behat/view_preferences.feature|Display the number of times a content is used in file details view
-contentbank/tests/behat/view_preferences.feature|There are several views for displaying contents into the content bank
-contentbank/tests/behat/edit_content.feature|Users can edit content if they have the required permission
-contentbank/tests/behat/events.feature|Content created and uploaded events when uploading a content file
-badges/tests/behat/criteria_cohort.feature|Award badge based on a multiple cohort membership or other criteria.
-badges/tests/behat/criteria_cohort.feature|Award badge based on a single cohort membership or other criteria.
-badges/tests/behat/view_badge.feature|Display badge with ANY criteria
-mod/workshop/tests/behat/workshop_completion_pass_grade.feature|As teacher, I can see the completion status of students in the workshop activity
-user/tests/behat/delete_users.feature|Deleting users who have unread messages sent or received
-mod/scorm/tests/behat/multisco_review_mode.feature|Test review mode with all scos completed.
-user/tests/behat/custom_profile_fields_manual.feature|Manual creation of basic custom profile fields
-contentbank/tests/behat/edit_content.feature|Users can see the Add button if there is content type available for creation
+Admins can replace the original .h5p file with a new one|contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature
+Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)|blocks/tests/behat/hidden_block_region.feature
+Display the number of times a content is used in file details view|contentbank/tests/behat/view_preferences.feature
+There are several views for displaying contents into the content bank|contentbank/tests/behat/view_preferences.feature
+Users can edit content if they have the required permission|contentbank/tests/behat/edit_content.feature
+Content created and uploaded events when uploading a content file|contentbank/tests/behat/events.feature
+Award badge based on a multiple cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Award badge based on a single cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Display badge with ANY criteria|badges/tests/behat/view_badge.feature
+As teacher, I can see the completion status of students in the workshop activity|mod/workshop/tests/behat/workshop_completion_pass_grade.feature
+Deleting users who have unread messages sent or received|user/tests/behat/delete_users.feature
+Test review mode with all scos completed.|mod/scorm/tests/behat/multisco_review_mode.feature
+Manual creation of basic custom profile fields|user/tests/behat/custom_profile_fields_manual.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+Block a user who then gets an elevated role|message/tests/behat/block_user.feature
+Preview a user preset as list view template in database|mod/data/tests/behat/preview_preset.feature
+Apply user preset from preview in database|mod/data/tests/behat/preview_preset.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+View full profiles of someone in the same group in a course with separate groups.|user/tests/behat/view_full_profile.feature
+Send a 'contact request' to someone to add a contact|message/tests/behat/message_drawer_manage_contacts.feature
+Unsent messages will notify users and give them a chance to send it|message/tests/behat/message_send_messages.feature
+Decline a 'contact request' from someone|message/tests/behat/message_drawer_manage_contacts.feature
+Users can create new content if they have the required permission|contentbank/tests/behat/edit_content.feature

--- a/flaky_tests/405_chrome_flaky_tests.txt
+++ b/flaky_tests/405_chrome_flaky_tests.txt
@@ -1,7 +1,7 @@
-mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
-mod/quiz/tests/behat/editing_remove_question.feature|Delete questions by clicking on the delete icon.
-admin/tool/dataprivacy/tests/behat/datadelete.feature|As a Privacy Officer, I cannot re-submit deletion data request without permission.
-mod/h5pactivity/tests/behat/sending_attempt.feature|Do various attempts and check them with the attempts and user grades reports
-mod/h5pactivity/tests/behat/recent_activity.feature|Student see only his own activity
-mod/h5pactivity/tests/behat/recent_activity.feature|Teacher see each student activity
-mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature|Verify that students can complete an H5P activity by achieving a passing grade
+Viewing a discussion while grading is fullscreen|mod/forum/tests/behat/grade_view_discussion.feature
+Delete questions by clicking on the delete icon.|mod/quiz/tests/behat/editing_remove_question.feature
+As a Privacy Officer, I cannot re-submit deletion data request without permission.|admin/tool/dataprivacy/tests/behat/datadelete.feature
+Do various attempts and check them with the attempts and user grades reports|mod/h5pactivity/tests/behat/sending_attempt.feature
+Student see only his own activity|mod/h5pactivity/tests/behat/recent_activity.feature
+Teacher see each student activity|mod/h5pactivity/tests/behat/recent_activity.feature
+Verify that students can complete an H5P activity by achieving a passing grade|mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature

--- a/flaky_tests/405_firefox_flaky_tests.txt
+++ b/flaky_tests/405_firefox_flaky_tests.txt
@@ -1,14 +1,23 @@
-contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature|Admins can replace the original .h5p file with a new one
-blocks/tests/behat/hidden_block_region.feature|Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)
-contentbank/tests/behat/view_preferences.feature|Display the number of times a content is used in file details view
-contentbank/tests/behat/view_preferences.feature|There are several views for displaying contents into the content bank
-contentbank/tests/behat/edit_content.feature|Users can edit content if they have the required permission
-contentbank/tests/behat/events.feature|Content created and uploaded events when uploading a content file
-badges/tests/behat/criteria_cohort.feature|Award badge based on a multiple cohort membership or other criteria.
-badges/tests/behat/criteria_cohort.feature|Award badge based on a single cohort membership or other criteria.
-badges/tests/behat/view_badge.feature|Display badge with ANY criteria
-mod/workshop/tests/behat/workshop_completion_pass_grade.feature|As teacher, I can see the completion status of students in the workshop activity
-user/tests/behat/delete_users.feature|Deleting users who have unread messages sent or received
-mod/scorm/tests/behat/multisco_review_mode.feature|Test review mode with all scos completed.
-user/tests/behat/custom_profile_fields_manual.feature|Manual creation of basic custom profile fields
-contentbank/tests/behat/edit_content.feature|Users can see the Add button if there is content type available for creation
+Admins can replace the original .h5p file with a new one|contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature
+Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)|blocks/tests/behat/hidden_block_region.feature
+Display the number of times a content is used in file details view|contentbank/tests/behat/view_preferences.feature
+There are several views for displaying contents into the content bank|contentbank/tests/behat/view_preferences.feature
+Users can edit content if they have the required permission|contentbank/tests/behat/edit_content.feature
+Content created and uploaded events when uploading a content file|contentbank/tests/behat/events.feature
+Award badge based on a multiple cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Award badge based on a single cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Display badge with ANY criteria|badges/tests/behat/view_badge.feature
+As teacher, I can see the completion status of students in the workshop activity|mod/workshop/tests/behat/workshop_completion_pass_grade.feature
+Deleting users who have unread messages sent or received|user/tests/behat/delete_users.feature
+Test review mode with all scos completed.|mod/scorm/tests/behat/multisco_review_mode.feature
+Manual creation of basic custom profile fields|user/tests/behat/custom_profile_fields_manual.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+Block a user who then gets an elevated role|message/tests/behat/block_user.feature
+Preview a user preset as list view template in database|mod/data/tests/behat/preview_preset.feature
+Apply user preset from preview in database|mod/data/tests/behat/preview_preset.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+View full profiles of someone in the same group in a course with separate groups.|user/tests/behat/view_full_profile.feature
+Send a 'contact request' to someone to add a contact|message/tests/behat/message_drawer_manage_contacts.feature
+Unsent messages will notify users and give them a chance to send it|message/tests/behat/message_send_messages.feature
+Decline a 'contact request' from someone|message/tests/behat/message_drawer_manage_contacts.feature
+Users can create new content if they have the required permission|contentbank/tests/behat/edit_content.feature

--- a/flaky_tests/500_chrome_flaky_tests.txt
+++ b/flaky_tests/500_chrome_flaky_tests.txt
@@ -1,7 +1,7 @@
-mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
-mod/quiz/tests/behat/editing_remove_question.feature|Delete questions by clicking on the delete icon.
-admin/tool/dataprivacy/tests/behat/datadelete.feature|As a Privacy Officer, I cannot re-submit deletion data request without permission.
-mod/h5pactivity/tests/behat/sending_attempt.feature|Do various attempts and check them with the attempts and user grades reports
-mod/h5pactivity/tests/behat/recent_activity.feature|Student see only his own activity
-mod/h5pactivity/tests/behat/recent_activity.feature|Teacher see each student activity
-mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature|Verify that students can complete an H5P activity by achieving a passing grade
+Viewing a discussion while grading is fullscreen|mod/forum/tests/behat/grade_view_discussion.feature
+Delete questions by clicking on the delete icon.|mod/quiz/tests/behat/editing_remove_question.feature
+As a Privacy Officer, I cannot re-submit deletion data request without permission.|admin/tool/dataprivacy/tests/behat/datadelete.feature
+Do various attempts and check them with the attempts and user grades reports|mod/h5pactivity/tests/behat/sending_attempt.feature
+Student see only his own activity|mod/h5pactivity/tests/behat/recent_activity.feature
+Teacher see each student activity|mod/h5pactivity/tests/behat/recent_activity.feature
+Verify that students can complete an H5P activity by achieving a passing grade|mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature

--- a/flaky_tests/500_firefox_flaky_tests.txt
+++ b/flaky_tests/500_firefox_flaky_tests.txt
@@ -1,14 +1,23 @@
-contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature|Admins can replace the original .h5p file with a new one
-blocks/tests/behat/hidden_block_region.feature|Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)
-contentbank/tests/behat/view_preferences.feature|Display the number of times a content is used in file details view
-contentbank/tests/behat/view_preferences.feature|There are several views for displaying contents into the content bank
-contentbank/tests/behat/edit_content.feature|Users can edit content if they have the required permission
-contentbank/tests/behat/events.feature|Content created and uploaded events when uploading a content file
-badges/tests/behat/criteria_cohort.feature|Award badge based on a multiple cohort membership or other criteria.
-badges/tests/behat/criteria_cohort.feature|Award badge based on a single cohort membership or other criteria.
-badges/tests/behat/view_badge.feature|Display badge with ANY criteria
-mod/workshop/tests/behat/workshop_completion_pass_grade.feature|As teacher, I can see the completion status of students in the workshop activity
-user/tests/behat/delete_users.feature|Deleting users who have unread messages sent or received
-mod/scorm/tests/behat/multisco_review_mode.feature|Test review mode with all scos completed.
-user/tests/behat/custom_profile_fields_manual.feature|Manual creation of basic custom profile fields
-contentbank/tests/behat/edit_content.feature|Users can see the Add button if there is content type available for creation
+Admins can replace the original .h5p file with a new one|contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature
+Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)|blocks/tests/behat/hidden_block_region.feature
+Display the number of times a content is used in file details view|contentbank/tests/behat/view_preferences.feature
+There are several views for displaying contents into the content bank|contentbank/tests/behat/view_preferences.feature
+Users can edit content if they have the required permission|contentbank/tests/behat/edit_content.feature
+Content created and uploaded events when uploading a content file|contentbank/tests/behat/events.feature
+Award badge based on a multiple cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Award badge based on a single cohort membership or other criteria.|badges/tests/behat/criteria_cohort.feature
+Display badge with ANY criteria|badges/tests/behat/view_badge.feature
+As teacher, I can see the completion status of students in the workshop activity|mod/workshop/tests/behat/workshop_completion_pass_grade.feature
+Deleting users who have unread messages sent or received|user/tests/behat/delete_users.feature
+Test review mode with all scos completed.|mod/scorm/tests/behat/multisco_review_mode.feature
+Manual creation of basic custom profile fields|user/tests/behat/custom_profile_fields_manual.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+Block a user who then gets an elevated role|message/tests/behat/block_user.feature
+Preview a user preset as list view template in database|mod/data/tests/behat/preview_preset.feature
+Apply user preset from preview in database|mod/data/tests/behat/preview_preset.feature
+Users can see the Add button if there is content type available for creation|contentbank/tests/behat/edit_content.feature
+View full profiles of someone in the same group in a course with separate groups.|user/tests/behat/view_full_profile.feature
+Send a 'contact request' to someone to add a contact|message/tests/behat/message_drawer_manage_contacts.feature
+Unsent messages will notify users and give them a chance to send it|message/tests/behat/message_send_messages.feature
+Decline a 'contact request' from someone|message/tests/behat/message_drawer_manage_contacts.feature
+Users can create new content if they have the required permission|contentbank/tests/behat/edit_content.feature

--- a/flaky_tests/501_chrome_flaky_tests.txt
+++ b/flaky_tests/501_chrome_flaky_tests.txt
@@ -1,7 +1,7 @@
-public/mod/forum/tests/behat/grade_view_discussion.feature|Viewing a discussion while grading is fullscreen
-public/mod/quiz/tests/behat/editing_remove_question.feature|Delete questions by clicking on the delete icon.
-public/admin/tool/dataprivacy/tests/behat/datadelete.feature|As a Privacy Officer, I cannot re-submit deletion data request without permission.
-public/mod/h5pactivity/tests/behat/sending_attempt.feature|Do various attempts and check them with the attempts and user grades reports
-public/mod/h5pactivity/tests/behat/recent_activity.feature|Student see only his own activity
-public/mod/h5pactivity/tests/behat/recent_activity.feature|Teacher see each student activity
-public/mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature|Verify that students can complete an H5P activity by achieving a passing grade
+Viewing a discussion while grading is fullscreen|public/mod/forum/tests/behat/grade_view_discussion.feature
+Delete questions by clicking on the delete icon.|public/mod/quiz/tests/behat/editing_remove_question.feature
+As a Privacy Officer, I cannot re-submit deletion data request without permission.|public/admin/tool/dataprivacy/tests/behat/datadelete.feature
+Do various attempts and check them with the attempts and user grades reports|public/mod/h5pactivity/tests/behat/sending_attempt.feature
+Student see only his own activity|public/mod/h5pactivity/tests/behat/recent_activity.feature
+Teacher see each student activity|public/mod/h5pactivity/tests/behat/recent_activity.feature
+Verify that students can complete an H5P activity by achieving a passing grade|public/mod/h5pactivity/tests/behat/h5pactivity_completion_pass_grade.feature

--- a/flaky_tests/501_firefox_flaky_tests.txt
+++ b/flaky_tests/501_firefox_flaky_tests.txt
@@ -1,14 +1,23 @@
-public/contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature|Admins can replace the original .h5p file with a new one
-public/blocks/tests/behat/hidden_block_region.feature|Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)
-public/contentbank/tests/behat/view_preferences.feature|Display the number of times a content is used in file details view
-public/contentbank/tests/behat/view_preferences.feature|There are several views for displaying contents into the content bank
-public/contentbank/tests/behat/edit_content.feature|Users can edit content if they have the required permission
-public/contentbank/tests/behat/events.feature|Content created and uploaded events when uploading a content file
-public/badges/tests/behat/criteria_cohort.feature|Award badge based on a multiple cohort membership or other criteria.
-public/badges/tests/behat/criteria_cohort.feature|Award badge based on a single cohort membership or other criteria.
-public/badges/tests/behat/view_badge.feature|Display badge with ANY criteria
-public/mod/workshop/tests/behat/workshop_completion_pass_grade.feature|As teacher, I can see the completion status of students in the workshop activity
-public/user/tests/behat/delete_users.feature|Deleting users who have unread messages sent or received
-public/mod/scorm/tests/behat/multisco_review_mode.feature|Test review mode with all scos completed.
-public/user/tests/behat/custom_profile_fields_manual.feature|Manual creation of basic custom profile fields
-public/contentbank/tests/behat/edit_content.feature|Users can see the Add button if there is content type available for creation
+Admins can replace the original .h5p file with a new one|public/contentbank/contenttype/h5p/tests/behat/admin_replace_content.feature
+Check that a region with only hidden blocks is not docked in editing mode (javascript enabled)|public/blocks/tests/behat/hidden_block_region.feature
+Display the number of times a content is used in file details view|public/contentbank/tests/behat/view_preferences.feature
+There are several views for displaying contents into the content bank|public/contentbank/tests/behat/view_preferences.feature
+Users can edit content if they have the required permission|public/contentbank/tests/behat/edit_content.feature
+Content created and uploaded events when uploading a content file|public/contentbank/tests/behat/events.feature
+Award badge based on a multiple cohort membership or other criteria.|public/badges/tests/behat/criteria_cohort.feature
+Award badge based on a single cohort membership or other criteria.|public/badges/tests/behat/criteria_cohort.feature
+Display badge with ANY criteria|public/badges/tests/behat/view_badge.feature
+As teacher, I can see the completion status of students in the workshop activity|public/mod/workshop/tests/behat/workshop_completion_pass_grade.feature
+Deleting users who have unread messages sent or received|public/user/tests/behat/delete_users.feature
+Test review mode with all scos completed.|public/mod/scorm/tests/behat/multisco_review_mode.feature
+Manual creation of basic custom profile fields|public/user/tests/behat/custom_profile_fields_manual.feature
+Users can see the Add button if there is content type available for creation|public/contentbank/tests/behat/edit_content.feature
+Block a user who then gets an elevated role|public/message/tests/behat/block_user.feature
+Preview a user preset as list view template in database|public/mod/data/tests/behat/preview_preset.feature
+Apply user preset from preview in database|public/mod/data/tests/behat/preview_preset.feature
+Users can see the Add button if there is content type available for creation|public/contentbank/tests/behat/edit_content.feature
+View full profiles of someone in the same group in a course with separate groups.|public/user/tests/behat/view_full_profile.feature
+Send a 'contact request' to someone to add a contact|public/message/tests/behat/message_drawer_manage_contacts.feature
+Unsent messages will notify users and give them a chance to send it|public/message/tests/behat/message_send_messages.feature
+Decline a 'contact request' from someone|public/message/tests/behat/message_drawer_manage_contacts.feature
+Users can create new content if they have the required permission|public/contentbank/tests/behat/edit_content.feature

--- a/inject_skip_tag
+++ b/inject_skip_tag
@@ -25,7 +25,7 @@ fi
 echo "Running inject_skip_tag script with ${FLAKY_SCENARIOS_FILE}"
 
 # Process each line in the file.
-while IFS='|' read -r filepath scenario_name; do
+while IFS='|' read -r scenario_name filepath; do
     # Skip empty lines or comments
     if [[ -z "${filepath}" || -z "${scenario_name}" || "${filepath}" =~ ^# ]]; then
         continue


### PR DESCRIPTION
This also flip the order in the flaky tests files to scenario|pathtotest to make it easier to copy straight from the build.