### PR TITLE
MDL-86190: Add skip tags for Chrome on stable branches

### DIFF
--- a/flaky_tests/405_chrome_flaky_tests.txt
+++ b/flaky_tests/405_chrome_flaky_tests.txt
@@ -6,4 +6,4 @@ Hide/Show toggle with javascript enabled|course/tests/behat/activities_visibilit
 As admin, enable allow filtering of exports by course setting, export data for a user and download it|admin/tool/dataprivacy/tests/behat/dataexport.feature
 Assign students to groups|group/tests/behat/create_groups.feature
 Overdue in date view|blocks/timeline/tests/behat/block_timeline_dates.feature
-Activities can not be added when the admin restricts the permissions|public/course/tests/behat/restrict_available_activities.feature
+Activities can not be added when the admin restricts the permissions|course/tests/behat/restrict_available_activities.feature

--- a/flaky_tests/405_chrome_flaky_tests.txt
+++ b/flaky_tests/405_chrome_flaky_tests.txt
@@ -6,3 +6,4 @@ Hide/Show toggle with javascript enabled|course/tests/behat/activities_visibilit
 As admin, enable allow filtering of exports by course setting, export data for a user and download it|admin/tool/dataprivacy/tests/behat/dataexport.feature
 Assign students to groups|group/tests/behat/create_groups.feature
 Overdue in date view|blocks/timeline/tests/behat/block_timeline_dates.feature
+Activities can not be added when the admin restricts the permissions|public/course/tests/behat/restrict_available_activities.feature

--- a/flaky_tests/500_chrome_flaky_tests.txt
+++ b/flaky_tests/500_chrome_flaky_tests.txt
@@ -6,3 +6,4 @@ Hide/Show toggle with javascript enabled|course/tests/behat/activities_visibilit
 As admin, enable allow filtering of exports by course setting, export data for a user and download it|admin/tool/dataprivacy/tests/behat/dataexport.feature
 Dragging a category over a category with no children shows an 'as new child' drop target|question/bank/managecategories/tests/behat/move_question_categories.feature
 Assign students to groups|group/tests/behat/create_groups.feature
+Activities can not be added when the admin restricts the permissions|public/course/tests/behat/restrict_available_activities.feature

--- a/flaky_tests/500_chrome_flaky_tests.txt
+++ b/flaky_tests/500_chrome_flaky_tests.txt
@@ -6,4 +6,4 @@ Hide/Show toggle with javascript enabled|course/tests/behat/activities_visibilit
 As admin, enable allow filtering of exports by course setting, export data for a user and download it|admin/tool/dataprivacy/tests/behat/dataexport.feature
 Dragging a category over a category with no children shows an 'as new child' drop target|question/bank/managecategories/tests/behat/move_question_categories.feature
 Assign students to groups|group/tests/behat/create_groups.feature
-Activities can not be added when the admin restricts the permissions|public/course/tests/behat/restrict_available_activities.feature
+Activities can not be added when the admin restricts the permissions|course/tests/behat/restrict_available_activities.feature

--- a/flaky_tests/501_chrome_flaky_tests.txt
+++ b/flaky_tests/501_chrome_flaky_tests.txt
@@ -6,3 +6,4 @@ Hide/Show toggle with javascript enabled|public/course/tests/behat/activities_vi
 As admin, enable allow filtering of exports by course setting, export data for a user and download it|public/admin/tool/dataprivacy/tests/behat/dataexport.feature
 Dragging a category over a category with no children shows an 'as new child' drop target|public/question/bank/managecategories/tests/behat/move_question_categories.feature
 Assign students to groups|public/group/tests/behat/create_groups.feature
+Activities can not be added when the admin restricts the permissions|public/course/tests/behat/restrict_available_activities.feature

--- a/flaky_tests/502_chrome_flaky_tests.txt
+++ b/flaky_tests/502_chrome_flaky_tests.txt
@@ -6,3 +6,4 @@ Hide/Show toggle with javascript enabled|public/course/tests/behat/activities_vi
 As admin, enable allow filtering of exports by course setting, export data for a user and download it|public/admin/tool/dataprivacy/tests/behat/dataexport.feature
 Dragging a category over a category with no children shows an 'as new child' drop target|public/question/bank/managecategories/tests/behat/move_question_categories.feature
 Assign students to groups|public/group/tests/behat/create_groups.feature
+Activities can not be added when the admin restricts the permissions|public/course/tests/behat/restrict_available_activities.feature

--- a/flaky_tests/503_chrome_flaky_tests.txt
+++ b/flaky_tests/503_chrome_flaky_tests.txt
@@ -6,3 +6,4 @@ Hide/Show toggle with javascript enabled|public/course/tests/behat/activities_vi
 As admin, enable allow filtering of exports by course setting, export data for a user and download it|public/admin/tool/dataprivacy/tests/behat/dataexport.feature
 Dragging a category over a category with no children shows an 'as new child' drop target|public/question/bank/managecategories/tests/behat/move_question_categories.feature
 Assign students to groups|public/group/tests/behat/create_groups.feature
+Activities can not be added when the admin restricts the permissions|public/course/tests/behat/restrict_available_activities.feature


### PR DESCRIPTION
This pull request adds the skip tag configuration for the flaky Behat test `Activities can not be added when the admin restricts the permissions` during Chrome browser runs. 

It covers the main branch (5.3) as well as all currently supported stable backport branches (4.5, 5.0, 5.1, and 5.2), as requested during peer review.

Jira issue: https://tracker.moodle.org/browse/MDL-86190